### PR TITLE
Fix translation control and overlay

### DIFF
--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ def main():
         ocr = OCRProcessor(config=config, output_queue=ocr_text_queue)
         translator = LLMTranslator(config=config, input_queue=ocr_text_queue, output_queue=translated_text_queue)
         overlay = TranslationOverlay(config=config, input_queue=translated_text_queue)
-        hotkeys = HotkeyManager(config=config, ocr=ocr, overlay=overlay)
+        hotkeys = HotkeyManager(config=config, ocr=ocr, overlay=overlay, translator=translator)
 
         # Start hotkey listener
         hotkey_thread = threading.Thread(target=hotkeys.listen, daemon=True)

--- a/tests/test_hotkeys.py
+++ b/tests/test_hotkeys.py
@@ -1,0 +1,33 @@
+import sys
+import types
+
+import pytest
+
+sys.modules['keyboard'] = types.SimpleNamespace(add_hotkey=lambda *a, **k: None, wait=lambda: None)
+sys.modules['llama_cpp'] = types.SimpleNamespace(Llama=object)
+
+from config import Config
+from utils.hotkeys import HotkeyManager
+
+class Dummy:
+    def __init__(self):
+        self.started = False
+    def start(self):
+        self.started = True
+    def stop(self):
+        self.started = False
+
+
+def test_toggle_translation():
+    cfg = Config()
+    ocr = Dummy()
+    overlay = Dummy()
+    translator = Dummy()
+
+    hk = HotkeyManager(config=cfg, ocr=ocr, overlay=overlay, translator=translator)
+
+    hk._toggle_translation()
+    assert ocr.started and overlay.started and translator.started
+
+    hk._toggle_translation()
+    assert not ocr.started and not overlay.started and not translator.started

--- a/translator/translator.py
+++ b/translator/translator.py
@@ -26,7 +26,7 @@ class LLMTranslator:
 
         self._running = False
         self._thread: Optional[threading.Thread] = None
-        self.llm = self._load_model()
+        self.llm: Optional[Llama] = None
 
     def _load_model(self) -> Llama:
         """Load LLM model with GPU configuration."""
@@ -43,6 +43,8 @@ class LLMTranslator:
     def start(self) -> None:
         """Start the translation thread."""
         if not self._running:
+            if self.llm is None:
+                self.llm = self._load_model()
             self._running = True
             self._thread = threading.Thread(target=self._run, daemon=True)
             self._thread.start()

--- a/ui/overlay_window.py
+++ b/ui/overlay_window.py
@@ -45,7 +45,8 @@ class TranslationOverlay:
         """Stop the overlay UI."""
         self._running = False
         if self._root:
-            self._root.quit()
+            # Ensure Tk operations run in the UI thread
+            self._root.after(0, self._root.quit)
         if self._thread:
             self._thread.join()
             logging.info("Translation overlay stopped.")
@@ -66,11 +67,11 @@ class TranslationOverlay:
         self._label = tk.Label(
             self._root,
             text="",
-            font=("Arial", 18),
+            font=(self.config.default_overlay_font, self.config.default_overlay_font_size),
             fg="white",
             bg="black",
             justify="left",
-            wraplength=800
+            wraplength=self.config.overlay_wrap_length,
         )
         self._label.pack(expand=True, fill="both")
 

--- a/utils/hotkeys.py
+++ b/utils/hotkeys.py
@@ -4,17 +4,16 @@ screen region selection and toggling translation mode.
 """
 
 import logging
-import threading
 import keyboard
 
-from typing import Callable
 from config import Config
+from translator.translator import LLMTranslator
 from utils.screenshot import select_screen_region
 
 class HotkeyManager:
     """Manages hotkeys for the Screen Translator app."""
 
-    def __init__(self, config: Config, ocr, overlay):
+    def __init__(self, config: Config, ocr, overlay, translator):
         """
         Initialize the hotkey manager.
 
@@ -22,10 +21,12 @@ class HotkeyManager:
             config (Config): App configuration.
             ocr (OCRProcessor): OCR component.
             overlay (TranslationOverlay): UI component.
+            translator (LLMTranslator): Translation component.
         """
         self.config = config
         self.ocr = ocr
         self.overlay = overlay
+        self.translator = translator
         self.translation_enabled = False
 
     def listen(self) -> None:
@@ -57,9 +58,11 @@ class HotkeyManager:
         self.translation_enabled = not self.translation_enabled
         if self.translation_enabled:
             self.ocr.start()
+            self.translator.start()
             self.overlay.start()
             logging.info("Translation enabled.")
         else:
             self.ocr.stop()
+            self.translator.stop()
             self.overlay.stop()
             logging.info("Translation disabled.")


### PR DESCRIPTION
## Summary
- wire up translator start/stop via `HotkeyManager`
- use config font settings for overlay label
- shut overlay UI down in a thread-safe way
- lazily load the LLM model
- add regression tests for translation toggle

## Testing
- `python -m py_compile main.py ocr/ocr_processor.py translator/translator.py utils/hotkeys.py utils/screenshot.py ui/overlay_window.py`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683caefe4a6083309011ae82ae41130a