### PR TITLE
Implement screen translator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Screen Translator
+
+A basic screen translation tool for Windows using local LLM models. Hotkeys allow
+selection of the OCR region, the output overlay, and toggling translation.
+
+## Features
+
+- Hotkeys (configurable in `config.py`)
+  - **Ctrl+Alt+1** – select region to perform OCR
+  - **Ctrl+Alt+2** – select region for translation overlay
+  - **Ctrl+Alt+3** – toggle translation on or off
+- OCR tuned for white text on complex backgrounds
+- Translation performed locally with `llama-cpp-python` on GPU index 1
+- Overlay window is semi-transparent and click-through
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Place the GGUF model file in the `models` folder (see `config.py` for name).
+3. Run the application:
+   ```bash
+   python main.py
+   ```
+4. Use the hotkeys to select the OCR and output regions and to enable
+   translation.
+
+## Notes
+
+This project is a lightweight example and may need additional tuning on Windows
+(e.g. installing Tesseract OCR and ensuring GPU drivers support `llama-cpp-python`).

--- a/main.py
+++ b/main.py
@@ -1,0 +1,165 @@
+import threading
+import time
+import sys
+import ctypes
+from typing import Optional, Tuple
+
+import keyboard
+import pytesseract
+from PIL import ImageGrab, ImageOps, Image
+import tkinter as tk
+from llama_cpp import Llama
+
+from config import Config
+
+
+def make_window_clickthrough(hwnd: int):
+    """Make a window transparent for mouse/keyboard events (Windows only)."""
+    if sys.platform != "win32":
+        return
+    GWL_EXSTYLE = -20
+    WS_EX_LAYERED = 0x00080000
+    WS_EX_TRANSPARENT = 0x00000020
+    style = ctypes.windll.user32.GetWindowLongW(hwnd, GWL_EXSTYLE)
+    style |= WS_EX_LAYERED | WS_EX_TRANSPARENT
+    ctypes.windll.user32.SetWindowLongW(hwnd, GWL_EXSTYLE, style)
+
+
+class RegionSelector:
+    """Interactive region selector using Tkinter."""
+
+    def select(self) -> Optional[Tuple[int, int, int, int]]:
+        result = {}
+        root = tk.Tk()
+        root.attributes("-fullscreen", True)
+        root.attributes("-alpha", 0.3)
+        root.attributes("-topmost", True)
+        root.config(cursor="cross")
+        canvas = tk.Canvas(root, bg="black")
+        canvas.pack(fill=tk.BOTH, expand=True)
+        rect = None
+        start = [0, 0]
+
+        def on_press(event):
+            nonlocal rect
+            start[0], start[1] = event.x, event.y
+            rect = canvas.create_rectangle(start[0], start[1], event.x, event.y, outline="red")
+
+        def on_move(event):
+            if rect:
+                canvas.coords(rect, start[0], start[1], event.x, event.y)
+
+        def on_release(event):
+            end = (event.x, event.y)
+            x1, y1 = start
+            x2, y2 = end
+            left = min(x1, x2)
+            top = min(y1, y2)
+            right = max(x1, x2)
+            bottom = max(y1, y2)
+            result["box"] = (left, top, right, bottom)
+            root.destroy()
+
+        canvas.bind("<ButtonPress-1>", on_press)
+        canvas.bind("<B1-Motion>", on_move)
+        canvas.bind("<ButtonRelease-1>", on_release)
+        root.mainloop()
+        return result.get("box")
+
+
+class OverlayWindow(threading.Thread):
+    """Semi-transparent overlay window for displaying translated text."""
+
+    def __init__(self, region: Tuple[int, int, int, int], cfg: Config):
+        super().__init__(daemon=True)
+        self.region = region
+        self.cfg = cfg
+        self.root = None
+        self.label = None
+
+    def run(self):
+        self.root = tk.Tk()
+        self.root.overrideredirect(True)
+        self.root.attributes("-topmost", True)
+        self.root.attributes("-alpha", 0.7)
+        x1, y1, x2, y2 = self.region
+        self.root.geometry(f"{x2 - x1}x{y2 - y1}+{x1}+{y1}")
+        self.root.configure(bg="black")
+        self.label = tk.Label(
+            self.root,
+            fg="white",
+            bg="black",
+            font=(self.cfg.default_overlay_font, self.cfg.default_overlay_font_size),
+            justify="left",
+            wraplength=self.cfg.overlay_wrap_length,
+        )
+        self.label.pack(fill=tk.BOTH, expand=True)
+        make_window_clickthrough(self.root.winfo_id())
+        self.root.mainloop()
+
+    def set_text(self, text: str):
+        if self.label:
+            self.label.config(text=text)
+
+
+class ScreenTranslator:
+    def __init__(self, cfg: Config):
+        self.cfg = cfg
+        self.ocr_region: Optional[Tuple[int, int, int, int]] = None
+        self.overlay_region: Optional[Tuple[int, int, int, int]] = None
+        self.overlay: Optional[OverlayWindow] = None
+        self.enabled = False
+        self.llm = Llama(model_path=cfg.llm_model_path, n_gpu_layers=cfg.llm_gpu_layers, main_gpu=cfg.llm_gpu_index)
+        keyboard.add_hotkey(cfg.hotkey_select_region, self.set_ocr_region)
+        keyboard.add_hotkey(cfg.hotkey_set_output_region, self.set_output_region)
+        keyboard.add_hotkey(cfg.hotkey_toggle_translation, self.toggle)
+
+    def set_ocr_region(self):
+        selector = RegionSelector()
+        region = selector.select()
+        if region:
+            self.ocr_region = region
+            print(f"OCR region set to {region}")
+
+    def set_output_region(self):
+        selector = RegionSelector()
+        region = selector.select()
+        if region:
+            self.overlay_region = region
+            if self.overlay:
+                self.overlay.root.destroy()
+            self.overlay = OverlayWindow(region, self.cfg)
+            self.overlay.start()
+            print(f"Output region set to {region}")
+
+    def toggle(self):
+        self.enabled = not self.enabled
+        state = "enabled" if self.enabled else "disabled"
+        print(f"Translation {state}")
+
+    def extract_text(self, img: Image.Image) -> str:
+        gray = ImageOps.grayscale(img)
+        binary = gray.point(lambda p: 255 if p > 200 else 0)
+        return pytesseract.image_to_string(binary, lang="eng").strip()
+
+    def translate(self, text: str) -> str:
+        prompt = self.cfg.llm_prompt_template.format(text=text)
+        result = self.llm(prompt, stop=["Translation:"], max_tokens=128)
+        return result["choices"][0]["text"].strip()
+
+    def run(self):
+        while True:
+            if self.enabled and self.ocr_region and self.overlay:
+                img = ImageGrab.grab(bbox=self.ocr_region)
+                text = self.extract_text(img)
+                if text:
+                    translation = self.translate(text)
+                    self.overlay.set_text(translation)
+            time.sleep(self.cfg.ocr_interval)
+
+
+if __name__ == "__main__":
+    config = Config()
+    app = ScreenTranslator(config)
+    print("Screen translator running. Use hotkeys to control.")
+    app.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Pillow
+pytesseract
+keyboard
+llama-cpp-python>=0.2.26
+pywin32


### PR DESCRIPTION
## Summary
- implement basic screen translator with OCR, hotkey support and overlay
- require Pillow, pytesseract, keyboard, llama-cpp-python and pywin32
- document usage in README

## Testing
- `python -m py_compile main.py config.py`

------
https://chatgpt.com/codex/tasks/task_b_683cb5f40e888330af8982a927bc8140